### PR TITLE
Pass through cfg attributes to getters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ name = "superstruct"
 proc-macro = true
 
 [dependencies]
-darling = "0.12.4"
-itertools = "0.10.0"
-proc-macro2 = "1.0.26"
-quote = "1.0.9"
-syn = "1.0.70"
+darling = "0.13.0"
+itertools = "0.10.1"
+proc-macro2 = "1.0.32"
+quote = "1.0.10"
+syn = "1.0.81"
 
 [dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.71"


### PR DESCRIPTION
While working on https://github.com/sigp/lighthouse/issues/2806 I noticed that `superstruct` doesn't handle `cfg` attributes gracefully. Previously it was applying the attribute to the fields of the variants but not to the getters, which lead to duplicate getter functions with the same name. This PR plumbs the `cfg` attributes through so that they apply to getters of all kinds (immutable, mutable, partial).

There are possibly more advanced interactions with `cfg` that we could want (like `cfg` only on specific variants) but I haven't thought that through in detail and I think this basic support is good enough for a lot of use-cases.