### PR TITLE
Add `no_enum` to disable top-level type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ struct StructOpts {
     /// Error type and expression to use for partial getter methods.
     #[darling(default)]
     partial_getter_error: ErrorOpts,
+    /// Turn off the generation of the top-level enum that binds the variants together.
+    #[darling(default)]
+    no_enum: bool,
 }
 
 /// Field-level configuration.
@@ -201,6 +204,11 @@ pub fn superstruct(args: TokenStream, input: TokenStream) -> TokenStream {
             }
         };
         output_items.push(variant_code.into());
+    }
+
+    // If the `no_enum` attribute is set, stop after generating variant structs.
+    if opts.no_enum {
+        return TokenStream::from_iter(output_items);
     }
 
     // Construct the top-level enum.

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -120,3 +120,20 @@ fn cfg_attribute() {
     });
     assert_eq!(*b.partial().unwrap(), 5);
 }
+
+#[test]
+fn no_enum() {
+    #[superstruct(variants(A, B), no_enum)]
+    struct Message {
+        #[superstruct(only(A))]
+        pub x: u64,
+        #[superstruct(only(B))]
+        pub y: u64,
+    }
+
+    type Message = MessageA;
+
+    let a: Message = Message { x: 0 };
+    let b: MessageB = MessageB { y: 0 };
+    assert_eq!(a.x, b.y);
+}

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -43,4 +43,5 @@ fn nesting() {
 
     assert_eq!(a.inner_a().unwrap().both, b.inner_b().unwrap().both);
     assert_eq!(a.inner().both(), b.inner().both());
+    assert_eq!(a.inner_a().unwrap().only_a, "world");
 }


### PR DESCRIPTION
Sometimes we just want `superstruct` to generate variants and no top-level type. This PR addresses this use by adding a `superstruct(no_enum)` attribute.

I also updated a test to pass lints introduced in Rust 1.57.0