### PR TITLE
Generate partial getters for references

### DIFF
--- a/tests/ref.rs
+++ b/tests/ref.rs
@@ -1,0 +1,29 @@
+use superstruct::superstruct;
+
+// Check that we can convert a Ref to an inner reference with the same lifetime as `message`.
+#[test]
+fn getter_and_partial_getter_lifetimes() {
+    #[superstruct(variants(A, B))]
+    struct Message {
+        pub x: String,
+        #[superstruct(only(B))]
+        pub y: String,
+    }
+
+    fn get_x(message: &Message) -> &String {
+        message.to_ref().x()
+    }
+
+    fn get_y(message: &Message) -> Result<&String, ()> {
+        message.to_ref().y()
+    }
+
+    let m = Message::B(MessageB {
+        x: "hello".into(),
+        y: "world".into(),
+    });
+    let x = get_x(&m);
+    let y = get_y(&m).unwrap();
+    assert_eq!(x, "hello");
+    assert_eq!(y, "world");
+}

--- a/tests/ref_mut.rs
+++ b/tests/ref_mut.rs
@@ -1,0 +1,36 @@
+use superstruct::superstruct;
+
+#[test]
+fn partial_getter() {
+    #[superstruct(variants(A, B))]
+    struct Message {
+        pub x: u64,
+        #[superstruct(only(B))]
+        pub y: u64,
+    }
+
+    let mut m = Message::B(MessageB { x: 0, y: 10 });
+    let mut mut_ref = m.to_mut();
+    *mut_ref.y_mut().unwrap() = 100;
+
+    assert_eq!(*m.y().unwrap(), 100);
+    assert_eq!(*m.x(), 0);
+}
+
+#[test]
+fn copy_partial_getter() {
+    #[superstruct(variants(A, B))]
+    struct Message {
+        #[superstruct(getter(copy))]
+        pub x: u64,
+        #[superstruct(only(B), partial_getter(copy))]
+        pub y: u64,
+    }
+
+    let mut m = Message::B(MessageB { x: 0, y: 10 });
+    let mut mut_ref = m.to_mut();
+    *mut_ref.y_mut().unwrap() = 100;
+
+    assert_eq!(m.y().unwrap(), 100);
+    assert_eq!(m.x(), 0);
+}


### PR DESCRIPTION
This commit adds partial getters to the `Ref` and `RefMut` types. This is a backwards-incompatible change as new auto-generated methods are introduced which could clash with existing ones.

Closes #8