### PR TITLE
Release v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "superstruct"
-version = "0.3.0"
-edition = "2018"
-description = "Proc-macro for quasi-subtyping"
+version = "0.4.0"
+edition = "2021"
+description = "Proc-macro for versioned data types"
 license = "Apache-2.0"
 repository = "https://github.com/sigp/superstruct"
 


### PR DESCRIPTION
New release containing the lifetime bound fixes and partial getters for `Ref` types.