### PR TITLE
Convert variants to top-level enum using `From`

### DIFF
--- a/src/from.rs
+++ b/src/from.rs
@@ -1,0 +1,20 @@
+//! Generate `From` implementations to convert variants to the top-level enum.
+use quote::quote;
+use syn::{Ident, ImplGenerics, TypeGenerics, WhereClause};
+
+pub fn generate_from_trait_impl(
+    type_name: &Ident,
+    impl_generics: &ImplGenerics,
+    ty_generics: &TypeGenerics,
+    where_clause: &Option<&WhereClause>,
+    variant_name: &Ident,
+    struct_name: &Ident,
+) -> proc_macro2::TokenStream {
+    quote! {
+        impl #impl_generics From<#struct_name #ty_generics> for #type_name #ty_generics #where_clause {
+            fn from(variant: #struct_name #ty_generics) -> Self {
+                Self::#variant_name(variant)
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use attributes::{IdentList, NestedMetaList};
 use darling::FromMeta;
+use from::generate_from_trait_impl;
 use itertools::Itertools;
 use macros::generate_all_map_macros;
 use proc_macro::TokenStream;
@@ -13,6 +14,7 @@ use syn::{
 };
 
 mod attributes;
+mod from;
 mod macros;
 mod naming;
 mod utils;
@@ -514,6 +516,19 @@ pub fn superstruct(args: TokenStream, input: TokenStream) -> TokenStream {
             opts.map_ref_mut_into.is_none(),
             "`map_ref_mut_into` is set but map macros are disabled"
         );
+    }
+
+    // Generate trait implementations.
+    for (variant_name, struct_name) in variant_names.iter().zip_eq(&struct_names) {
+        let from_impl = generate_from_trait_impl(
+            type_name,
+            impl_generics,
+            ty_generics,
+            where_clause,
+            variant_name,
+            struct_name,
+        );
+        output_items.push(from_impl.into());
     }
 
     TokenStream::from_iter(output_items)

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -1,0 +1,34 @@
+use std::fmt::Display;
+use superstruct::superstruct;
+
+#[superstruct(variants(Good, Bad), variant_attributes(derive(Debug, PartialEq)))]
+#[derive(Debug, PartialEq)]
+pub struct Message<T: Display> {
+    #[superstruct(getter(copy))]
+    id: u64,
+    #[superstruct(only(Good))]
+    good: T,
+    #[superstruct(only(Bad))]
+    bad: T,
+}
+
+#[test]
+fn generic_from() {
+    let message_good_variant = MessageGood {
+        id: 0,
+        good: "hello",
+    };
+    let message_bad_variant = MessageBad {
+        id: 1,
+        bad: "noooooo",
+    };
+
+    let message_good = Message::from(message_good_variant);
+    let message_bad = Message::from(message_bad_variant);
+
+    assert_eq!(message_good.id(), 0);
+    assert_eq!(*message_good.good().unwrap(), "hello");
+
+    assert_eq!(message_bad.id(), 1);
+    assert_eq!(*message_bad.bad().unwrap(), "noooooo");
+}


### PR DESCRIPTION
This PR implements `From` so we can convert from variant structs to the top-level type without boilerplate. For now only an owning implementation is added, with references to be handled by an upcoming `ToRef` trait.

This is the first of two changes to support @ethDreamer's work on Capella.