### PR TITLE
Implement variant-specific attributes

### DIFF
--- a/book/src/config/struct.md
+++ b/book/src/config/struct.md
@@ -55,6 +55,18 @@ This can be used to derive traits, perform conditional compilation, etc.
 
 **Format**: any.
 
+## Specific variant attributes
+
+```
+#[superstruct(specific_variant_attributes(A(...), B(...), ...))]
+```
+
+Similar to `variant_attributes`, but applies the attributes _only_ to the named variants. This
+is useful if e.g. one variant needs to derive a trait which the others cannot, or if another
+procedural macro is being invoked on the variant struct which requires different parameters.
+
+**Format**: zero or more variant names, with variant attributes nested in parens
+
 ## `Ref` attributes
 
 ```

--- a/tests/specific_variant_attributes.rs
+++ b/tests/specific_variant_attributes.rs
@@ -1,0 +1,23 @@
+use superstruct::superstruct;
+
+#[superstruct(
+    variants(IsCopy, IsNotCopy),
+    variant_attributes(derive(Debug, PartialEq, Clone)),
+    specific_variant_attributes(IsCopy(derive(Copy)))
+)]
+#[derive(Clone, PartialEq, Debug)]
+pub struct Thing {
+    pub x: u64,
+    #[superstruct(only(IsNotCopy))]
+    pub y: String,
+}
+
+#[test]
+fn copy_the_thing() {
+    fn copy<T: Copy>(t: T) -> (T, T) {
+        (t, t)
+    }
+
+    let x = ThingIsCopy { x: 0 };
+    assert_eq!(copy(x), (x, x));
+}


### PR DESCRIPTION
This PR adds support for applying different attributes to each variant. I want this primarily to integrate with a new library I'm working on, [`metastruct`](https://github.com/sigp/metastruct), which could be used to generate field mapping macros for superstruct variant structs. Each macro needs a unique name, so we need to make a different `metastruct` call for each variant.

There's an example of `metastruct` usage here: https://github.com/sigp/metastruct/blob/662cde78840c6cdfd6e688c155b87c6b4f1300d2/examples/hello_world.rs#L3-L6