### PR TITLE
Add field attribute to disable (partial) getter generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ name = "superstruct"
 proc-macro = true
 
 [dependencies]
-darling = "0.13.0"
-itertools = "0.10.1"
-proc-macro2 = "1.0.32"
-quote = "1.0.10"
-syn = "1.0.82"
-smallvec = "1.8.0"
+darling = "0.20.10"
+itertools = "0.13.0"
+proc-macro2 = "1.0.89"
+quote = "1.0.37"
+syn = "2.0.86"
+smallvec = "1.13.2"
 
 [dev-dependencies]
 serde = { version = "1.0.130", features = ["derive"] }

--- a/book/src/config/field.md
+++ b/book/src/config/field.md
@@ -69,6 +69,20 @@ The error type for partial getters can currently only be configured on a per-str
 via the [`partial_getter_error`](./struct.md#partial-getter-error) attribute, although this may
 change in a future release.
 
+## No Getter
+Disable the generation of (partial) getter functions for this field.
+This can be used for when two fields have the same name but different types:
+
+```rust
+#[superstruct(variants(A, B))]
+struct NoGetter {
+    #[superstruct(only(A), no_getter)]
+    pub x: u64,
+    #[superstruct(only(B), no_getter)]
+    pub x: String,
+}
+```
+
 ## Flatten
 
 ```

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,6 +1,6 @@
 //! Utilities to help with parsing configuration attributes.
-use darling::{Error, FromMeta};
-use syn::{Ident, NestedMeta};
+use darling::{export::NestedMeta, Error, FromMeta};
+use syn::Ident;
 
 /// Parse a list of nested meta items.
 ///

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -138,3 +138,15 @@ fn no_enum() {
     let b: MessageB = MessageB { y: 0 };
     assert_eq!(a.x, b.y);
 }
+
+#[test]
+#[allow(dead_code)]
+fn no_getter() {
+    #[superstruct(variants(A, B))]
+    struct NoGetter {
+        #[superstruct(only(A), no_getter)]
+        pub x: u64,
+        #[superstruct(only(B), no_getter)]
+        pub x: String,
+    }
+}


### PR DESCRIPTION
This allows the following struct to work:
```rust
#[superstruct(variants(A, B))]
struct NoGetter {
    #[superstruct(only(A), no_getter)]
    pub x: u64,
    #[superstruct(only(B), no_getter)]
    pub x: String,
}
```

This PR also upgrades Syn to 2.0 and Darling to 0.20.

Fixes #43.